### PR TITLE
Feat : 좋아요 삭제 구현

### DIFF
--- a/src/main/java/com/github/backend_1st/repository/likes/LikeJpaRepository.java
+++ b/src/main/java/com/github/backend_1st/repository/likes/LikeJpaRepository.java
@@ -4,8 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LikeJpaRepository extends JpaRepository<LikeEntity, Integer> {
     List<LikeEntity> findByCommentId(Integer commentIdInt);
+
+    Optional<LikeEntity> findByCommentIdAndUserId(Integer commentIdInt, Integer userId);
 }

--- a/src/main/java/com/github/backend_1st/service/likeService/LikeService.java
+++ b/src/main/java/com/github/backend_1st/service/likeService/LikeService.java
@@ -40,4 +40,14 @@ public class LikeService {
         likeJpaRepository.save(likeEntity);
         return "like post success";
     }
+
+    public String deleteLike(String commentId,Integer userId) {
+        Integer commentIdInt = Integer.valueOf(commentId);
+        CommentEntity comment = commentJpaRepository.findById(commentIdInt)
+                .orElseThrow(()-> new RuntimeException("Comment can not found"));
+        LikeEntity like = likeJpaRepository.findByCommentIdAndUserId(commentIdInt , userId)
+                .orElseThrow(() -> new RuntimeException("No like found for this user on the specified comment"));
+        likeJpaRepository.delete(like);
+        return "like delete success";
+    }
 }

--- a/src/main/java/com/github/backend_1st/web/controller/likes/LikeController.java
+++ b/src/main/java/com/github/backend_1st/web/controller/likes/LikeController.java
@@ -36,6 +36,8 @@ public class LikeController {
         String token = jwtTokenProvider.resolveToken(request);
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Integer userId = jwtTokenProvider.getUserIdFromToken(token); // 사용자 ID 추출
+            System.out.println(token);
+            System.out.println(userId);
             String returnMessage = likeService.saveLike(commentId, userId);
             Map<String, String> response = new HashMap<>();
             response.put("message", returnMessage);
@@ -45,4 +47,17 @@ public class LikeController {
         }
     }
 
+    @DeleteMapping("/likes/{commentId}")
+    public ResponseEntity<Map<String , String>> deleteLike(@PathVariable String commentId , HttpServletRequest request){
+        String token = jwtTokenProvider.resolveToken(request);
+        if (token != null && jwtTokenProvider.validateToken(token)){
+            Integer userId = jwtTokenProvider.getUserIdFromToken(token);
+            String returnMessage = likeService.deleteLike(commentId , userId);
+            Map<String, String> response = new HashMap<>();
+            response.put("message", returnMessage);
+            return ResponseEntity.ok(response);
+        }else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "Error processing request"));
+        }
+    }
 }


### PR DESCRIPTION
특정 댓글의 좋아요 중 로그인한 유저가 작성한 좋아요를 삭제하는 로직 구현했습니다. 하지만 데이터베이스 부분에서 users table과 user_principal의 데이터가 완벽하게 매칭되어야 정확하게 로직이 구동되는것을 확인했습니다. 실험에 보고 싶은 분들은 확인해보시는거 추천드립니다.